### PR TITLE
docs: merge 9.1.x into 9.2.x (bring the 9.1→9.2 upgrade guide forward)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -107,6 +107,7 @@
     * [Updating Drush to the Latest Stable Version](developers/updating-varbase/updating-drush-to-the-latest-stable-version.md)
     * [Version Update Guides](developers/updating-varbase/version-update-guides/README.md)
       * [Updating Varbase \~9.0 to Drupal 10](developers/updating-varbase/version-update-guides/updating-varbase-9.0-to-drupal-10.md)
+      * [Updating from Varbase 9.1 to 9.2](developers/updating-varbase/version-update-guides/updating-from-varbase-9.1-to-9.2.md)
       * [Switch from CKEditor 4 to CKEditor 5 in Varbase \~9.1.0](developers/updating-varbase/version-update-guides/switch-from-ckeditor-4-to-ckeditor-5-in-varbase-9.1.0.md)
       * [Updating from Varbase 8.x to 9.x](developers/updating-varbase/version-update-guides/updating-from-varbase-8.x-to-9.x.md)
     * [Enabling Automatic Updates](developers/updating-varbase/enabling-automatic-updates.md)

--- a/developers/updating-varbase/version-update-guides/updating-from-varbase-9.1-to-9.2.md
+++ b/developers/updating-varbase/version-update-guides/updating-from-varbase-9.1-to-9.2.md
@@ -19,6 +19,25 @@ DO NOT update Varbase directly on production.
 
 Follow the steps in order. Each step has one action, the exact command to run, and how to confirm it worked.
 
+## Varbase 9.2.0 Release Notes and References
+
+Read these before you upgrade so you have the full picture.
+
+* **Varbase 9.2.0 CHANGELOG:** [https://git.drupalcode.org/project/varbase/-/blob/9.2.x/CHANGELOG.md](https://git.drupalcode.org/project/varbase/-/blob/9.2.x/CHANGELOG.md)
+* **Release plan / tracking issue:** [Plan: release Varbase 9.2.0 (#3608857)](https://www.drupal.org/project/varbase/issues/3608857)
+* **Vartheme (Bootstrap 4 - SASS) 9.2.0:** [https://www.drupal.org/project/vartheme\_bs4](https://www.drupal.org/project/vartheme_bs4)
+
+**What changed in 9.2.0 — read before upgrading:**
+
+* Varbase `9.2.0` is **Drupal `~11.4`-only** and **drops Drupal 10**. It is the continuation of the `9.1.x` line (`9.1.13` &#x2192; `9.2.0`).
+* Modules removed in Drupal 11 / Varbase `9.2.x`: **Action** and **Statistics** (removed from Drupal 11 core), **Google Analytics Reports** (dropped from **Varbase Total Control**), and **Social Auth Twitter** / the Twitter (X) sign-in option (dropped). This is why you uninstall them first in step 2.
+* Hooks were converted to **Drupal 11 OOP hook classes** across the profile and all modules, and permission/config provisioning moved to **Default Varbase recipes** (the old Module Installer Factory class was dropped). These are transparent on the upgrade path.
+* Ships **Vartheme (Bootstrap 4 - SASS) 9.2.0**. Remember that Drupal 11 ships **jQuery 4**, which breaks Bootstrap 4 JavaScript unless the jQuery gate is raised to `>=5` (already handled in Vartheme 9.2.0) — see **Troubleshooting**.
+
+{% hint style="warning" %}
+Only use `9.2.0` to update an **existing Varbase `9.1.x` site**. It is not a fresh-start or migration track.
+{% endhint %}
+
 ## 1. Before You Begin
 
 You need **PHP `8.4`** and a working **DDEV** project, and you must stay on **one consistent database engine** for the whole upgrade (do not change the database server or its version mid-upgrade).
@@ -37,6 +56,17 @@ ddev drush status
 ```
 
 You should see **Drupal `10.6.x`** and **Varbase `9.1.x`**. If you are not on Varbase `9.1.x` yet, update to the latest `9.1.x` first, then come back here.
+
+3. **Upgrade your own custom modules and themes for Drupal 11.** Varbase and its contrib stack are already Drupal 11-ready, but **your project's custom code is not covered by this upgrade**. Audit and fix it before you run the updates:
+
+* Run the [Upgrade Status](https://www.drupal.org/project/upgrade_status) module against every **custom module and theme** and fix the reported deprecations.
+* Set `core_version_requirement: ^11` (or `^10 || ^11`) in each custom `*.info.yml`.
+* Replace removed/deprecated APIs (for example `theme_get_setting()` &#x2192; `ThemeSettingsProvider::getSetting()`).
+* If a custom theme is based on **Bootstrap 4**, review its JavaScript for **jQuery 4** compatibility (see **Troubleshooting**).
+
+{% hint style="warning" %}
+**Human developers and AI agents:** this upgrade only covers Varbase, its modules, and its theme. It does **not** touch your project's custom modules or custom themes. Before continuing, make sure that code is Drupal 11-compatible. An automated agent running this flow should **ask the site owner to upgrade (or confirm the upgrade of) the custom module and theme code** first, rather than assuming it is ready.
+{% endhint %}
 
 {% hint style="info" %}
 The **update** path (`updatedb` + config import) is safe. Only a **fresh** Varbase `9.2` install needs the extra `vardot/drupal-core-patches` `site:install` core fix &#x2014; the upgrade does **not**.
@@ -227,7 +257,7 @@ You do not need to act on these &#x2014; the `9.2.x` components and their patche
 {% hint style="info" %}
 ### For AI Agents and Automated Upgrades
 
-The **`varbase-upgrade-9-1-to-9-2`** agent in [Vardot/dev-ai-agents](https://github.com/Vardot/dev-ai-agents) runs this exact flow end to end (uninstall dropped modules &#x2192; repoint composer &#x2192; reapply patches &#x2192; run updates &#x2192; verify), always through **review-gated MRs/PRs** and **never releasing**.
+The **`varbase-upgrade-9-1-to-9-2`** agent in [Vardot/dev-ai-agents](https://github.com/Vardot/dev-ai-agents) runs this exact flow end to end (uninstall dropped modules &#x2192; repoint composer &#x2192; reapply patches &#x2192; run updates &#x2192; verify), always through **review-gated MRs/PRs** and **never releasing**. The agent should also **ask the site owner to upgrade the project's custom modules and custom themes for Drupal 11** (see step 1) before running the updates &#x2014; that code is outside the Varbase upgrade.
 {% endhint %}
 
 {% content-ref url="switch-from-ckeditor-4-to-ckeditor-5-in-varbase-9.1.0.md" %}

--- a/developers/updating-varbase/version-update-guides/updating-from-varbase-9.1-to-9.2.md
+++ b/developers/updating-varbase/version-update-guides/updating-from-varbase-9.1-to-9.2.md
@@ -27,11 +27,16 @@ Read these before you upgrade so you have the full picture.
 * **Release plan / tracking issue:** [Plan: release Varbase 9.2.0 (#3608857)](https://www.drupal.org/project/varbase/issues/3608857)
 * **Vartheme (Bootstrap 4 - SASS) 9.2.0:** [https://www.drupal.org/project/vartheme\_bs4](https://www.drupal.org/project/vartheme_bs4)
 
-**What changed in 9.2.0 — read before upgrading:**
+### What Changed in 9.2.0 — Read Before Upgrading
 
 * Varbase `9.2.0` is **Drupal `~11.4`-only** and **drops Drupal 10**. It is the continuation of the `9.1.x` line (`9.1.13` &#x2192; `9.2.0`).
+
 * Modules removed in Drupal 11 / Varbase `9.2.x`: **Action** and **Statistics** (removed from Drupal 11 core), **Google Analytics Reports** (dropped from **Varbase Total Control**), and **Social Auth Twitter** / the Twitter (X) sign-in option (dropped). This is why you uninstall them first in step 2.
+
+* **LB UX** (`drupal/lb_ux`) had no Drupal 11 release, so it is now **bundled inside Varbase Layout Builder** as the `modules/lb_ux` submodule (with the Drupal 11 fixes from [#3464547](https://www.drupal.org/i/3464547) ported). If your `composer.json` requires `drupal/lb_ux`, **remove that require** during the upgrade — see step 3.
+
 * Hooks were converted to **Drupal 11 OOP hook classes** across the profile and all modules, and permission/config provisioning moved to **Default Varbase recipes** (the old Module Installer Factory class was dropped). These are transparent on the upgrade path.
+
 * Ships **Vartheme (Bootstrap 4 - SASS) 9.2.0**. Remember that Drupal 11 ships **jQuery 4**, which breaks Bootstrap 4 JavaScript unless the jQuery gate is raised to `>=5` (already handled in Vartheme 9.2.0) — see **Troubleshooting**.
 
 {% hint style="warning" %}
@@ -48,6 +53,10 @@ You need **PHP `8.4`** and a working **DDEV** project, and you must stay on **on
 ddev export-db --file=pre-upgrade.sql.gz
 cp -a docroot/sites/default/files ../files-backup
 ```
+
+{% hint style="info" %}
+Keep this backup until the upgrade is verified and live on production. It is your one-command way back if a step goes wrong.
+{% endhint %}
 
 2. **Confirm your starting point.**
 
@@ -85,7 +94,9 @@ ddev drush pm:uninstall action statistics block_content_permissions social_auth_
 * `social_auth_twitter` — dropped in Varbase `9.2.x`.
 * `google_analytics_reports` (+ `google_analytics_reports_api`) — dropped from **Varbase Total Control** on `9.2.x`.
 
-Doing this before you touch Composer means the later `drush updatedb` will not stop with a "module does not exist" error, and you never have to edit `core.extension` or `system.schema` by hand.
+{% hint style="info" %}
+Do this **before** you touch Composer. Then the later `drush updatedb` will not stop with a "module does not exist" error, and you never have to edit `core.extension` or `system.schema` by hand.
+{% endhint %}
 
 ## 3. Repoint the `composer.json` File
 
@@ -156,12 +167,31 @@ Do **not** add `vardot/drupal-core-patches` here. It is a **metapackage** (a sto
 
 **This lets the Varbase and Drupal core patches be applied to their target packages.**
 
+7. Remove any standalone **LB UX** require, if your project has one:
+
+```json
+"drupal/lb_ux": "..."
+```
+
+Delete that line. **LB UX** is now bundled inside **Varbase Layout Builder** as the `modules/lb_ux` submodule.
+
+{% hint style="warning" %}
+**Remove `drupal/lb_ux` from `composer.json`.** It has no Drupal 11 release, so a standalone require will fail to resolve. Varbase Layout Builder now ships it as the `modules/lb_ux` submodule (with the Drupal 11 fixes from [#3464547](https://www.drupal.org/i/3464547) ported), so you get the same functionality without the separate package.
+{% endhint %}
+
 ## 4. Update Composer and Reapply Patches
 
-1. Remove the old lock file and resolve the new dependency tree:
+With `composer.json` repointed, resolve the new dependency tree, then run a full install so every patch is reapplied.
+
+1. Remove the old lock file:
 
 ```bash
 rm -f composer.lock
+```
+
+2. Resolve the new dependency tree:
+
+```bash
 ddev composer update -W
 ```
 
@@ -171,7 +201,7 @@ If Varbase stays on `9.1.x` (Composer kept the old version), pin it explicitly a
 ddev composer require "vardot/varbase:9.2.x-dev" -W
 ```
 
-2. Run a full install:
+3. Run a full install so the patches are reapplied:
 
 ```bash
 ddev composer install
@@ -183,8 +213,13 @@ The second command re-applies the Varbase and Drupal core patches, including on 
 
 ## 5. Run the Database Updates
 
+With the code on the `9.2.x` line, apply the database updates and rebuild the cache:
+
 ```bash
 ddev drush updatedb -y
+```
+
+```bash
 ddev drush cache:rebuild
 ```
 

--- a/developers/updating-varbase/version-update-guides/updating-from-varbase-9.1-to-9.2.md
+++ b/developers/updating-varbase/version-update-guides/updating-from-varbase-9.1-to-9.2.md
@@ -1,0 +1,235 @@
+---
+description: >-
+  Update the Drupal 11-only continuation of the 9.1.x line, from Varbase 9.1 on
+  Drupal ~10.6 to Varbase 9.2 on Drupal ~11.4
+metaLinks:
+  alternates:
+    - >-
+      https://app.gitbook.com/s/u42G9phGWi3WksRxVOC1/developers/updating-varbase/version-update-guides/updating-from-varbase-9.1-to-9.2
+---
+
+# Updating from Varbase 9.1 to 9.2
+
+Varbase `~9.2.0` is the **Drupal 11-only** continuation of the `9.1.x` line. It runs on **Drupal `~11.4`** and **drops support for Drupal `~10`**. This guide walks you, step by step, through updating an existing **Varbase `9.1.x`** site (on **Drupal `~10.6`**) to **Varbase `9.2.0`** (on **Drupal `~11.4`**), keeping your content and configuration.
+
+{% hint style="warning" %}
+Do this in a **local or development environment** first. Once it is done and tested, push the code and build to production.\
+DO NOT update Varbase directly on production.
+{% endhint %}
+
+Follow the steps in order. Each step has one action, the exact command to run, and how to confirm it worked.
+
+## 1. Before You Begin
+
+You need **PHP `8.4`** and a working **DDEV** project, and you must stay on **one consistent database engine** for the whole upgrade (do not change the database server or its version mid-upgrade).
+
+1. **Back up the database and the files directory.** If anything goes wrong you can restore from here.
+
+```bash
+ddev export-db --file=pre-upgrade.sql.gz
+cp -a docroot/sites/default/files ../files-backup
+```
+
+2. **Confirm your starting point.**
+
+```bash
+ddev drush status
+```
+
+You should see **Drupal `10.6.x`** and **Varbase `9.1.x`**. If you are not on Varbase `9.1.x` yet, update to the latest `9.1.x` first, then come back here.
+
+{% hint style="info" %}
+The **update** path (`updatedb` + config import) is safe. Only a **fresh** Varbase `9.2` install needs the extra `vardot/drupal-core-patches` `site:install` core fix &#x2014; the upgrade does **not**.
+{% endhint %}
+
+## 2. Uninstall the Drupal 11-Dropped Modules
+
+A few modules that Varbase `9.1.x` used are gone in Drupal 11 / Varbase `9.2.x`. Uninstall them **now, while you are still on 9.1.x and their code still exists**, so Drupal can run each module's own clean uninstall:
+
+```bash
+ddev drush pm:uninstall action statistics block_content_permissions social_auth_twitter google_analytics_reports google_analytics_reports_api -y
+```
+
+* `action`, `statistics` — removed from Drupal 11 core.
+* `block_content_permissions` — merged into Drupal core.
+* `social_auth_twitter` — dropped in Varbase `9.2.x`.
+* `google_analytics_reports` (+ `google_analytics_reports_api`) — dropped from **Varbase Total Control** on `9.2.x`.
+
+Doing this before you touch Composer means the later `drush updatedb` will not stop with a "module does not exist" error, and you never have to edit `core.extension` or `system.schema` by hand.
+
+## 3. Repoint the `composer.json` File
+
+Open the **root `composer.json`** and change these lines so the site targets the `9.2.x` line.
+
+1. Point Varbase at the new line:
+
+```json
+"vardot/varbase": "~9.2.0"
+```
+
+Use `"9.2.x-dev"` until the `9.2.0` tag is released. **This is what pulls in Varbase 9.2 and Drupal 11.**
+
+2. Move the Drupal core helpers to Drupal 11:
+
+```json
+"drupal/core-composer-scaffold": "~11.4.0",
+"drupal/core-project-message": "~11.4.0"
+```
+
+**These keep the scaffolded files and the project message in step with Drupal `~11.4`.**
+
+3. Point the patch package at the new line:
+
+```json
+"vardot/varbase-patches": "~9.2.0"
+```
+
+**This brings in the Varbase `9.2.x` patch set and, through it, `vardot/drupal-core-patches` (the Drupal core patches).**
+
+4. Allow dev releases until the tag exists:
+
+```json
+"minimum-stability": "dev"
+```
+
+**Composer needs this to resolve `9.2.x-dev` before the `9.2.0` tag is published. You can remove it once you are on the stable `~9.2.0`.**
+
+5. Allow the two patch **plugins** to run:
+
+```json
+"config": {
+    "allow-plugins": {
+        "cweagans/composer-patches": true,
+        "vardot/varbase-patches": true
+    }
+}
+```
+
+**Composer only lets listed plugins execute; these two apply the patches.**
+
+{% hint style="warning" %}
+Do **not** add `vardot/drupal-core-patches` here. It is a **metapackage** (a store of Drupal core patches), **not** a plugin. The only Varbase patch plugin is **`vardot/varbase-patches`**.
+{% endhint %}
+
+6. Allow both patch packages to patch other dependencies:
+
+```json
+"extra": {
+    "composer-patches": {
+        "allowed-dependency-patches": [
+            "vardot/varbase-patches",
+            "vardot/drupal-core-patches"
+        ]
+    }
+}
+```
+
+**This lets the Varbase and Drupal core patches be applied to their target packages.**
+
+## 4. Update Composer and Reapply Patches
+
+1. Remove the old lock file and resolve the new dependency tree:
+
+```bash
+rm -f composer.lock
+ddev composer update -W
+```
+
+If Varbase stays on `9.1.x` (Composer kept the old version), pin it explicitly and update again:
+
+```bash
+ddev composer require "vardot/varbase:9.2.x-dev" -W
+```
+
+2. Run a full install:
+
+```bash
+ddev composer install
+```
+
+{% hint style="info" %}
+The second command re-applies the Varbase and Drupal core patches, including on packages **whose version did not change** during the update. Run it so no patch is silently skipped.
+{% endhint %}
+
+## 5. Run the Database Updates
+
+```bash
+ddev drush updatedb -y
+ddev drush cache:rebuild
+```
+
+A successful run lists each pending update, prints `[success]` for each, and ends without any `[error]`. If it stops on a leftover module, see **Troubleshooting** below.
+
+If your site tracks configuration, export and review the changes before you commit them:
+
+```bash
+ddev drush config:export
+```
+
+## 6. Verify Your Site
+
+Click through this checklist:
+
+1. **Check the version:**
+
+```bash
+ddev drush status
+```
+
+You should now see **Drupal `~11.4`** and **Varbase `9.2`**.
+
+2. **Check the log is clean:**
+
+```bash
+ddev drush watchdog:show --severity=Error
+```
+
+This should print nothing (no errors).
+
+3. **Open the front end** &#x2014; visit the homepage as an anonymous visitor and confirm it renders.
+4. **Open the admin pages** &#x2014; **Administration** \ _**Content**_ (`/admin/content`) and **Administration** \ _**Reports**_ \ _**Status report**_ (`/admin/reports/status`).
+5. **Create or edit a page** and save it, to confirm content editing works.
+
+{% hint style="success" %}
+When the version reads Drupal `~11.4` / Varbase `9.2`, the log is empty, and content editing works, the upgrade is done. Now push your code and build to production.
+{% endhint %}
+
+## 7. Troubleshooting
+
+{% hint style="warning" %}
+**`updatedb` stops with "module X does not exist".** A module was still enabled when its code was removed. Uninstall it the same way as in step 2 and run the updates again:
+
+```bash
+ddev drush pm:uninstall <module> -y
+ddev drush updatedb -y
+```
+{% endhint %}
+
+{% hint style="warning" %}
+**A Bootstrap 4 theme's JavaScript breaks after the update.** Drupal 11 ships **jQuery 4**, which breaks **Bootstrap 4** JavaScript. Raise the theme's jQuery gate to `>=5` (as **Vartheme (Bootstrap 4)** does in [#3607041](https://www.drupal.org/i/3607041)), or move the front end to **Bootstrap 5**. See the [jQuery 4.0 upgrade guide](https://jquery.com/upgrade-guide/4.0/).
+{% endhint %}
+
+{% hint style="warning" %}
+**A social login provider throws an error.** The `9.2.x` line already pins **Social Auth / Social API** to `~4.1` / `~4.0` (the provider modules lag Social Auth `4.2`) and applies a patch that removes the dangling `configure` route on **Social Auth LinkedIn** ([#3507495](https://www.drupal.org/i/3507495)). Make sure `vardot/varbase-patches` is allowed to run (step 3) so these fixes are applied.
+{% endhint %}
+
+## Reference: Drupal 11 Changes Carried by the 9.2.x Line
+
+{% hint style="info" %}
+You do not need to act on these &#x2014; the `9.2.x` components and their patches already handle them. They are listed so you know what changed under the hood.
+{% endhint %}
+
+* **Social Auth / Social API** are pinned to `~4.1` / `~4.0` because the provider modules lag Social Auth `4.2`, plus the Social Auth LinkedIn route patch (upstream [#3507495](https://www.drupal.org/i/3507495)).
+* **`theme_get_setting()`** is deprecated in Drupal 11; themes now read settings through `ThemeSettingsProvider::getSetting()`.
+* **jQuery 4** in Drupal 11 core breaks Bootstrap 4 JavaScript; the jQuery gate is raised to `>=5` ([#3607041](https://www.drupal.org/i/3607041)), or move to Bootstrap 5.
+* The contrib **Default Content** module is dropped. On a **fresh** Varbase `9.2` install the demo content is now provided by **Drupal core Default Content**. This has **no effect on the upgrade path** &#x2014; your existing content is untouched.
+
+{% hint style="info" %}
+### For AI Agents and Automated Upgrades
+
+The **`varbase-upgrade-9-1-to-9-2`** agent in [Vardot/dev-ai-agents](https://github.com/Vardot/dev-ai-agents) runs this exact flow end to end (uninstall dropped modules &#x2192; repoint composer &#x2192; reapply patches &#x2192; run updates &#x2192; verify), always through **review-gated MRs/PRs** and **never releasing**.
+{% endhint %}
+
+{% content-ref url="switch-from-ckeditor-4-to-ckeditor-5-in-varbase-9.1.0.md" %}
+[switch-from-ckeditor-4-to-ckeditor-5-in-varbase-9.1.0.md](switch-from-ckeditor-4-to-ckeditor-5-in-varbase-9.1.0.md)
+{% endcontent-ref %}

--- a/developers/updating-varbase/version-update-guides/updating-from-varbase-9.1-to-9.2.md
+++ b/developers/updating-varbase/version-update-guides/updating-from-varbase-9.1-to-9.2.md
@@ -181,34 +181,32 @@ Delete that line. **LB UX** is now bundled inside **Varbase Layout Builder** as 
 
 ## 4. Update Composer and Reapply Patches
 
-With `composer.json` repointed, resolve the new dependency tree, then run a full install so every patch is reapplied.
+With `composer.json` repointed, do a **full clean rebuild** so Composer resolves everything from scratch and reapplies every patch in one pass.
 
-1. Remove the old lock file:
-
-```bash
-rm -f composer.lock
-```
-
-2. Resolve the new dependency tree:
+1. Delete the lock files and the vendor tree:
 
 ```bash
-ddev composer update -W
+rm -rf composer.lock patches.lock.json vendor/
 ```
 
-If Varbase stays on `9.1.x` (Composer kept the old version), pin it explicitly and update again:
-
-```bash
-ddev composer require "vardot/varbase:9.2.x-dev" -W
-```
-
-3. Run a full install so the patches are reapplied:
+2. Reinstall from scratch:
 
 ```bash
 ddev composer install
 ```
 
 {% hint style="info" %}
-The second command re-applies the Varbase and Drupal core patches, including on packages **whose version did not change** during the update. Run it so no patch is silently skipped.
+Deleting `composer.lock`, `patches.lock.json` and `vendor/` lets `ddev composer install` resolve everything fresh in a single pass. It switches the patch system to `cweagans/composer-patches ~2.0`, brings in the new Drupal `~11.4` vendor tree, and pulls the Drupal core patches from `vardot/drupal-core-patches ~11.4.0` (through `vardot/varbase-patches`).
+
+Because the lock file is gone, `ddev composer install` resolves fresh, writes a **new** `composer.lock`, and applies all patches. So you do **not** need a separate `composer update -W` followed by `composer install` &#x2014; this one command does it all.
+{% endhint %}
+
+{% hint style="warning" %}
+If `ddev drush status` afterwards still shows **Varbase `9.1.x`**, require the new version explicitly and reinstall:
+
+```bash
+ddev composer require "vardot/varbase:9.2.x-dev" -W
+```
 {% endhint %}
 
 ## 5. Run the Database Updates

--- a/developers/varbase-patches.md
+++ b/developers/varbase-patches.md
@@ -24,6 +24,47 @@ Use `"vardot/varbase-patches": "~9.1.0"`
 
 > &#x20; <mark style="color:$primary;background-color:$primary;">with</mark> <mark style="color:$primary;background-color:$primary;"></mark><mark style="color:$primary;background-color:$primary;">**Varbase \~9.1.0**</mark> <mark style="color:$primary;background-color:$primary;">**CKEditor 4**</mark> <mark style="color:$primary;background-color:$primary;"></mark><mark style="color:$primary;background-color:$primary;">and</mark> <mark style="color:$primary;background-color:$primary;"></mark><mark style="color:$primary;background-color:$primary;">**Drupal \~10**</mark> &#x20;
 
+## Drupal Core Patches
+
+Drupal **core** patches are managed in a dedicated package, [**`vardot/drupal-core-patches`**](https://github.com/Vardot/drupal-core-patches), so that **Varbase** can always track the latest **Drupal core** release while keeping core patches separate from contrib patches.
+
+[**`vardot/varbase-patches`**](https://github.com/Vardot/varbase-patches) **requires** **`vardot/drupal-core-patches`**. The core-patches package stores the curated **Drupal core** patches with **one git branch per Drupal core `major.minor`** — `10.4.x`, `10.5.x`, `10.6.x`, `11.1.x`, `11.2.x`, `11.3.x`, `11.4.x`, `12.0.x` — plus a flat **`patches`** branch that stores the actual `.patch` files. Each `drupal-core-patches` release `require`s `drupal/core ~<minor>.0`, so **Composer** automatically selects the patch set that matches the **Drupal core** version installed in your project.
+
+On this branch `vardot/varbase-patches` requires:
+
+```
+"require": {
+    "vardot/drupal-core-patches": "~10 || ~11 || ~12"
+}
+```
+
+{% hint style="warning" %}
+`vardot/drupal-core-patches` is a **metapackage** — a storage for **Drupal core** patches — **not** a **Composer** plugin. The only **Varbase** patch *plugin* is `vardot/varbase-patches`. List `vardot/drupal-core-patches` only under `extra.composer-patches.allowed-dependency-patches`, and **never** under `config.allow-plugins`.
+{% endhint %}
+
+### Allowing the patch packages
+
+The `config.allow-plugins` and `extra.composer-patches.allowed-dependency-patches` keys live in `vardot/varbase-project` (the project template), not in the individual modules. Allow the patch **plugin** and accept patches from both patch packages:
+
+```
+{
+    "config": {
+        "allow-plugins": {
+            "cweagans/composer-patches": true,
+            "vardot/varbase-patches": true
+        }
+    },
+    "extra": {
+        "composer-patches": {
+            "allowed-dependency-patches": [
+                "vardot/varbase-patches",
+                "vardot/drupal-core-patches"
+            ]
+        }
+    }
+}
+```
+
 ### Managing Only Local Patches for Projects <a href="#managing-only-local-patches-for-projects" id="managing-only-local-patches-for-projects"></a>
 
 When there's a need to handle local patches for a project without relying on Varbase Patches.
@@ -107,7 +148,10 @@ List of package-name patterns. Only packages matching this list contribute patch
 {
   "extra": {
     "composer-patches": {
-      "allowed-dependency-patches": ["vardot/varbase-patches"]
+      "allowed-dependency-patches": [
+        "vardot/varbase-patches",
+        "vardot/drupal-core-patches"
+      ]
     }
   }
 }
@@ -167,9 +211,9 @@ Two equivalent schemas are accepted. The v1-style description-keyed map (matches
   "extra": {
     "patches-ignore": {
       "vardot/varbase-patches": {
-        "drupal/core": {
-          "Issue #2869592: Disabled update module shouldn't produce a status report warning":
-          "https://www.drupal.org/files/issues/2869592-remove-update-warning-7.patch"
+        "drupal/recaptcha": {
+          "fix: #3588269 Make Drupal8Post::submit() compatible with parent":
+          "https://git.drupalcode.org/project/recaptcha/-/commit/68b0f86d1e930ed78f795a97a2fc207be35b3260.diff"
         }
       }
     }
@@ -196,6 +240,28 @@ Or a flat array of URLs:
 Matching is done by URL string. The description (if you use the dict form) is informational only — `vardot/varbase-patches` and the consumer can disagree on the description and the URL still matches.
 
 
+
+### Ignoring Drupal Core Patches
+
+`vardot/drupal-core-patches` is an ordinary dependency that contributes patches through the dependency resolver, so the same `extra` keys control it — use `vardot/drupal-core-patches` as the **source** package and `drupal/core` as the **target**.
+
+#### Ignore a single Drupal core patch
+
+```
+{
+    "extra": {
+        "patches-ignore": {
+            "vardot/drupal-core-patches": {
+                "drupal/core": {
+                    "Issue #3606822: ContainerBuilder synthetic kernel on install": "https://git.drupalcode.org/project/drupal/-/merge_requests/16159.patch"
+                }
+            }
+        }
+    }
+}
+```
+
+Matching is by URL string, the same as for `vardot/varbase-patches`.
 
 ## Composer Command to Clean up Any Merge Request Patches
 


### PR DESCRIPTION
Closes #50.

Branch-merge PR (**base `9.2.x`, head `9.1.x`**) to bring the new **Updating from Varbase 9.1 to 9.2** guide and all the recent `9.1.x` documentation updates forward to the `9.2.x` docs branch.

**Included from `9.1.x`:**
- `docs: #42 Add 'Updating from Varbase 9.1 to 9.2' version update guide (#43)`
- `docs: #44 Add 9.2.0 release notes + custom-code upgrade tips to the 9.1-to-9.2 guide (#45)`
- `docs: #46 Document LB UX bundling and improve readability of the 9.1-to-9.2 guide (#47)`
- `docs: Drupal Core Patches via Varbase Patches (9.1.x) (#23)`
- …and, once merged into `9.1.x`, the full clean rebuild change (#48 / PR #49) will flow in automatically since this PR tracks the `9.1.x` branch tip.

**Conflicts:** none. A local test merge of `9.1.x` into `9.2.x` was clean — `SUMMARY.md` merges automatically and the new guide file adds cleanly. No temporary resolution branch was needed.

**Do not self-merge** — left for maintainer review.

AI-Generated: Yes (Used Claude Code to open the branch-merge PR)

### Checkpoints
- [x] File an issue about this project
- [x] Addition/Change/Update/Fix to this project
- [ ] Testing to ensure no regression
- [ ] Automated unit/functional testing coverage
- [ ] Developer Documentation support on feature change/addition
- [ ] User Guide Documentation support on feature change/addition
- [ ] UX/UI designer responsibilities
- [ ] Accessibility and Readability
- [ ] Reviewed by a human
- [ ] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Review with the product owner
- [ ] Update Release Notes
- [ ] Release
