### PR TITLE
docs: #52 Use the stable ~9.2.0 range (not 9.2.x-dev) in the 9.1-to-9.2 guide

### DIFF
--- a/developers/updating-varbase/version-update-guides/updating-from-varbase-9.1-to-9.2.md
+++ b/developers/updating-varbase/version-update-guides/updating-from-varbase-9.1-to-9.2.md
@@ -108,7 +108,7 @@ Open the **root `composer.json`** and change these lines so the site targets the
 "vardot/varbase": "~9.2.0"
 ```
 
-Use `"9.2.x-dev"` until the `9.2.0` tag is released. **This is what pulls in Varbase 9.2 and Drupal 11.**
+**`~9.2.0` resolves to the latest stable Varbase `9.2` release, which is what pulls in Varbase 9.2 and Drupal 11.**
 
 2. Move the Drupal core helpers to Drupal 11:
 
@@ -127,15 +127,7 @@ Use `"9.2.x-dev"` until the `9.2.0` tag is released. **This is what pulls in Var
 
 **This brings in the Varbase `9.2.x` patch set and, through it, `vardot/drupal-core-patches` (the Drupal core patches).**
 
-4. Allow dev releases until the tag exists:
-
-```json
-"minimum-stability": "dev"
-```
-
-**Composer needs this to resolve `9.2.x-dev` before the `9.2.0` tag is published. You can remove it once you are on the stable `~9.2.0`.**
-
-5. Allow the two patch **plugins** to run:
+4. Allow the two patch **plugins** to run:
 
 ```json
 "config": {
@@ -152,7 +144,7 @@ Use `"9.2.x-dev"` until the `9.2.0` tag is released. **This is what pulls in Var
 Do **not** add `vardot/drupal-core-patches` here. It is a **metapackage** (a store of Drupal core patches), **not** a plugin. The only Varbase patch plugin is **`vardot/varbase-patches`**.
 {% endhint %}
 
-6. Allow both patch packages to patch other dependencies:
+5. Allow both patch packages to patch other dependencies:
 
 ```json
 "extra": {
@@ -167,7 +159,7 @@ Do **not** add `vardot/drupal-core-patches` here. It is a **metapackage** (a sto
 
 **This lets the Varbase and Drupal core patches be applied to their target packages.**
 
-7. Remove any standalone **LB UX** require, if your project has one:
+6. Remove any standalone **LB UX** require, if your project has one:
 
 ```json
 "drupal/lb_ux": "..."
@@ -205,7 +197,7 @@ Because the lock file is gone, `ddev composer install` resolves fresh, writes a 
 If `ddev drush status` afterwards still shows **Varbase `9.1.x`**, require the new version explicitly and reinstall:
 
 ```bash
-ddev composer require "vardot/varbase:9.2.x-dev" -W
+ddev composer require "vardot/varbase:~9.2.0" -W
 ```
 {% endhint %}
 


### PR DESCRIPTION
Closes #52. Follow-up to #48 / PR #49 (merged).

Makes the *Updating from Varbase 9.1 to 9.2* guide read as a stable `~9.1.0 → ~9.2.0` upgrade, with **no `9.2.x-dev` anywhere**:

- **Fallback require** (Update Composer step): `ddev composer require "vardot/varbase:~9.2.0" -W` (was `vardot/varbase:9.2.x-dev`).
- **Repoint composer.json** step 1 reworded: `~9.2.0` resolves to the latest stable Varbase 9.2 release (dropped the "use 9.2.x-dev until the tag is released" note).
- Removed the now-unneeded `minimum-stability: dev` step and renumbered the composer steps (1–6).

Verified: no `x-dev` / `minimum-stability` remains in the file; the guide reads `~9.1.0 → ~9.2.0` throughout (`9.2.x` still appears only as the version-line name, never `9.2.x-dev`).

**Change:** `developers/updating-varbase/version-update-guides/updating-from-varbase-9.1-to-9.2.md` — only the stable-range edits.

**Target branch:** `9.1.x`. Separate PR because #49 was already merged. Same forward-port note applies (`9.2.x` / `10.0.x` / `10.1.x` / `11.0.x`); the open `9.1.x → 9.2.x` merge PR #51 will carry it forward once merged.

AI-Generated: Yes (Used Claude Code to make the change)

### Checkpoints
- [x] File an issue about this project
- [x] Addition/Change/Update/Fix to this project
- [ ] Testing to ensure no regression
- [ ] Automated unit/functional testing coverage
- [ ] Developer Documentation support on feature change/addition
- [ ] User Guide Documentation support on feature change/addition
- [ ] UX/UI designer responsibilities
- [ ] Accessibility and Readability
- [x] Reviewed by a human
- [x] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Review with the product owner
- [ ] Update Release Notes
- [ ] Release
