### PR TITLE
Polish the Default Canvas Patterns guide: simpler title, no em dashes, steps first

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -89,7 +89,7 @@
       * [Hero Slider Container and Hero Slide With Drupal Canvas](developers/theme-development-with-varbase/drupal-canvas/hero-slider-container-and-hero-slide-with-drupal-canvas.md)
       * [Building Common Page Types With Drupal Canvas](developers/theme-development-with-varbase/drupal-canvas/building-common-page-types-with-drupal-canvas.md)
       * [Building Pages With the Drupal Canvas AI Agent](developers/theme-development-with-varbase/drupal-canvas/building-pages-with-the-drupal-canvas-ai-agent.md)
-      * [Default Canvas Patterns (Ready-Made Sections)](developers/theme-development-with-varbase/drupal-canvas/default-canvas-patterns.md)
+      * [Default Canvas Patterns](developers/theme-development-with-varbase/drupal-canvas/default-canvas-patterns.md)
     * [Troubleshooting Theme Switch Issues](developers/theme-development-with-varbase/troubleshooting-theme-switch-issues.md)
     * [Integration of Varbase with Storybook](developers/theme-development-with-varbase/integration-of-varbase-with-storybook.md)
     * [Add Preloaded Fonts in Vartheme](developers/theme-development-with-varbase/add-preloaded-fonts-in-vartheme.md)

--- a/developers/theme-development-with-varbase/drupal-canvas/default-canvas-patterns.md
+++ b/developers/theme-development-with-varbase/drupal-canvas/default-canvas-patterns.md
@@ -1,23 +1,23 @@
 ---
 description: >-
-  The 14 ready-made Canvas Patterns that ship with Varbase — what each section is,
+  The 14 default Canvas Patterns that ship with Varbase, what each section is,
   and how to insert, edit and publish one in Drupal Canvas, no code.
 ---
 
-# Default Canvas Patterns (Ready-Made Sections)
+# Default Canvas Patterns
 
 **Canvas Patterns** are ready-made page sections that ship with **Varbase**. Each one is a
-complete, on-brand block — a hero slider, a set of feature cards, a contact form, a
-call-to-action banner — that you drop onto a page in **Drupal Canvas** and adjust in the
-browser, **no code**. They were extracted from the real Varbase Starter demo pages, so every
-pattern is something you can already see running on the site.
+complete, on-brand block that you drop onto a page in **Drupal Canvas** and adjust in the
+browser, with **no code**. A pattern can be a hero slider, a set of feature cards, a contact
+form or a call-to-action banner. They were extracted from the real Varbase Starter demo pages,
+so every pattern is something you can already see running on the site.
 
 ## What Is a Canvas Pattern?
 
-A **component** is a single piece — a heading, an image, a button, a card. A **pattern** is a
-whole section built from many components that are already arranged and filled with sensible
-starter content. Instead of placing a section, then columns, then each card and heading by
-hand, you insert one pattern and the entire section appears at once, ready to edit.
+A **component** is a single piece, such as a heading, an image, a button or a card. A
+**pattern** is a whole section built from many components that are already arranged and filled
+with sensible starter content. Instead of placing a section, then columns, then each card and
+heading by hand, you insert one pattern and the entire section appears at once, ready to edit.
 
 Patterns live on their own tab in the editor's **Library**, next to **Components**. Varbase
 ships **14** of them.
@@ -29,106 +29,129 @@ Only **content** patterns appear here. Administrative and system pieces are neve
 patterns, so a builder cannot accidentally drop a system element onto a page.
 {% endhint %}
 
+## How to Use a Pattern
+
+Open the page you want to work on in **Drupal Canvas**. From **Administration** \ **Content** \
+_**Pages**_, choose **Edit** on the page, then follow these steps.
+
+1. Open the **Library** from the left toolbar and switch to the **Patterns** tab.
+2. **Right-click** the pattern you want and choose **Insert**. The whole section is added to
+   the page.
+3. Drag it up or down, or manage it in the **Layers** panel, to place it where you want.
+4. Select any piece inside it, such as a heading, a paragraph, a button or an image, and change
+   its content and settings on the right.
+5. When you are happy, **Review** your changes and **Publish**.
+
+![Step 2: right-click a pattern and choose Insert.](<../../../.gitbook/assets/Canvas Patterns - Insert Menu.png>)
+
+![The inserted section appears on the page, with its settings on the right.](<../../../.gitbook/assets/Canvas Patterns - Pattern Settings.png>)
+
+{% hint style="info" %}
+**Insert as many times as you like.** Each time you insert a pattern it comes in as a fresh,
+independent copy. You can use the same pattern several times on one page and edit each copy on
+its own, and changing one never changes the others.
+{% endhint %}
+
 ## The Pattern Catalog
 
-All 14 patterns, shown on the real Varbase demo pages they came from. Each note says what to
-reach for it when.
+All 14 patterns, shown on the real Varbase demo pages they came from. Each note says when to
+reach for it.
 
 ### Hero Slider
 
-_Use it for:_ the top of a landing page — a rotating set of full-width slides with a headline,
-a short line of text and a button.
+_Use it for:_ the top of a landing page. It shows a rotating set of full-width slides, each
+with a headline, a short line of text and a button.
 
-![Hero Slider — a rotating full-width opener for a landing page.](<../../../.gitbook/assets/Canvas Patterns - Hero Slider.png>)
+![Hero Slider: a rotating full-width opener for a landing page.](<../../../.gitbook/assets/Canvas Patterns - Hero Slider.png>)
 
 ### Page Intro Banner
 
-_Use it for:_ the header band of an inside page — a title, a short intro line and the breadcrumb
-trail over a background image.
+_Use it for:_ the header band of an inside page. It shows a title, a short intro line and the
+breadcrumb trail over a background image.
 
-![Page Intro Banner — a titled header band for an inside page.](<../../../.gitbook/assets/Canvas Patterns - Page Intro Banner.png>)
+![Page Intro Banner: a titled header band for an inside page.](<../../../.gitbook/assets/Canvas Patterns - Page Intro Banner.png>)
 
 ### Text with Cards
 
-_Use it for:_ an introduction beside a small set of highlight cards — a heading, a short
-paragraph and a button on one side, cards on the other.
+_Use it for:_ an introduction beside a small set of highlight cards. A heading, a short
+paragraph and a button sit on one side, with cards on the other.
 
-![Text with Cards — an intro paragraph paired with highlight cards.](<../../../.gitbook/assets/Canvas Patterns - Text with Cards.png>)
+![Text with Cards: an intro paragraph paired with highlight cards.](<../../../.gitbook/assets/Canvas Patterns - Text with Cards.png>)
 
 ### Feature Cards
 
 _Use it for:_ a tidy grid of features, each with an icon, a short title and a line of text.
 
-![Feature Cards — a grid of icon-and-text feature cards.](<../../../.gitbook/assets/Canvas Patterns - Feature Cards.png>)
+![Feature Cards: a grid of icon-and-text feature cards.](<../../../.gitbook/assets/Canvas Patterns - Feature Cards.png>)
 
 ### Counters
 
-_Use it for:_ a row of key numbers — a big figure with a short label under each — to show scale
-or results.
+_Use it for:_ a row of key numbers. Each shows a big figure with a short label under it, to
+convey scale or results.
 
-![Counters — a row of headline numbers with labels.](<../../../.gitbook/assets/Canvas Patterns - Counters.png>)
+![Counters: a row of headline numbers with labels.](<../../../.gitbook/assets/Canvas Patterns - Counters.png>)
 
 ### Feature Highlight
 
-_Use it for:_ spotlighting one thing — a heading and a paragraph beside a supporting image.
+_Use it for:_ spotlighting one thing, with a heading and a paragraph beside a supporting image.
 
-![Feature Highlight — one idea spotlighted beside an image.](<../../../.gitbook/assets/Canvas Patterns - Feature Highlight.png>)
+![Feature Highlight: one idea spotlighted beside an image.](<../../../.gitbook/assets/Canvas Patterns - Feature Highlight.png>)
 
 ### Latest Blog Posts
 
-_Use it for:_ an automatic list of your most recent articles with a link to see them all — the
+_Use it for:_ an automatic list of your most recent articles with a link to see them all. The
 list updates itself as you publish.
 
-![Latest Blog Posts — a self-updating list of recent articles.](<../../../.gitbook/assets/Canvas Patterns - Latest Blog Posts.png>)
+![Latest Blog Posts: a self-updating list of recent articles.](<../../../.gitbook/assets/Canvas Patterns - Latest Blog Posts.png>)
 
 ### FAQ Accordion
 
-_Use it for:_ a set of questions and answers where each answer opens and closes on click,
-keeping the page short.
+_Use it for:_ a set of questions and answers where each answer opens and closes on click, which
+keeps the page short.
 
-![FAQ Accordion — expandable questions and answers.](<../../../.gitbook/assets/Canvas Patterns - FAQ Accordion.png>)
+![FAQ Accordion: expandable questions and answers.](<../../../.gitbook/assets/Canvas Patterns - FAQ Accordion.png>)
 
 ### Image Cards
 
 _Use it for:_ a row of cards that each pair a picture or icon with a short line of text, plus a
 button below the row.
 
-![Image Cards — a row of picture-and-text cards.](<../../../.gitbook/assets/Canvas Patterns - Image Cards.png>)
+![Image Cards: a row of picture-and-text cards.](<../../../.gitbook/assets/Canvas Patterns - Image Cards.png>)
 
 ### Contact Form with Info
 
-_Use it for:_ a contact page — a full enquiry form beside a panel of contact details and a
-button.
+_Use it for:_ a contact page. It places a full enquiry form beside a panel of contact details
+and a button.
 
-![Contact Form with Info — an enquiry form beside contact details.](<../../../.gitbook/assets/Canvas Patterns - Contact Form with Info.png>)
+![Contact Form with Info: an enquiry form beside contact details.](<../../../.gitbook/assets/Canvas Patterns - Contact Form with Info.png>)
 
 ### Call to Action Cards
 
-_Use it for:_ pointing people to two next steps — two side-by-side cards, each with a heading,
-a line of text and a button.
+_Use it for:_ pointing people to two next steps, shown as two side-by-side cards, each with a
+heading, a line of text and a button.
 
-![Call to Action Cards — two side-by-side next steps.](<../../../.gitbook/assets/Canvas Patterns - Call to Action Cards.png>)
+![Call to Action Cards: two side-by-side next steps.](<../../../.gitbook/assets/Canvas Patterns - Call to Action Cards.png>)
 
 ### Call to Action Banner
 
-_Use it for:_ one strong, full-width prompt — a headline, a short line and a single button —
+_Use it for:_ one strong, full-width prompt with a headline, a short line and a single button,
 usually near the bottom of a page.
 
-![Call to Action Banner — a full-width prompt with one button.](<../../../.gitbook/assets/Canvas Patterns - Call to Action Banner.png>)
+![Call to Action Banner: a full-width prompt with one button.](<../../../.gitbook/assets/Canvas Patterns - Call to Action Banner.png>)
 
 ### Site Header
 
-_Use it for:_ dropping the standard site branding and main navigation composition onto a page —
-a ready-made copy of the site-wide header.
+_Use it for:_ dropping the standard site branding and main navigation onto a page. It is a
+ready-made copy of the site-wide header.
 
-![Site Header — the standard branding and navigation composition.](<../../../.gitbook/assets/Canvas Patterns - Site Header.png>)
+![Site Header: the standard branding and navigation composition.](<../../../.gitbook/assets/Canvas Patterns - Site Header.png>)
 
 ### Site Footer
 
-_Use it for:_ dropping the standard footer composition onto a page — footer menus, social links
-and copyright.
+_Use it for:_ dropping the standard footer onto a page, with its footer menus, social links and
+copyright.
 
-![Site Footer — the standard footer menus, social links and copyright.](<../../../.gitbook/assets/Canvas Patterns - Site Footer.png>)
+![Site Footer: the standard footer menus, social links and copyright.](<../../../.gitbook/assets/Canvas Patterns - Site Footer.png>)
 
 {% hint style="info" %}
 **Header and Footer, reused.** The **Site Header** and **Site Footer** patterns are ready-made
@@ -136,56 +159,32 @@ copies of the site-wide header and footer. They let a builder place that same co
 a page when a design calls for it, without rebuilding it by hand.
 {% endhint %}
 
-## How to Use a Pattern
-
-Open the page you want to work on in **Drupal Canvas** (from **Administration** \ **Content** \
-_**Pages**_, choose **Edit**), then:
-
-1. Open the **Library** from the left toolbar and switch to the **Patterns** tab.
-2. **Right-click** the pattern you want and choose **Insert**. The whole section is added to the
-   page.
-3. Drag it up or down, or manage it in the **Layers** panel, to place it where you want.
-4. Select any piece inside it — a heading, a paragraph, a button, an image — and change its
-   content and settings on the right.
-5. When you are happy, **Review** your changes and **Publish**.
-
-![Step 2 — right-click a pattern and choose Insert.](<../../../.gitbook/assets/Canvas Patterns - Insert Menu.png>)
-
-![The inserted section appears on the page, with its settings on the right.](<../../../.gitbook/assets/Canvas Patterns - Pattern Settings.png>)
-
-{% hint style="info" %}
-**Insert as many times as you like.** Each time you insert a pattern it comes in as a fresh,
-independent copy. You can use the same pattern several times on one page and edit each copy on
-its own — changing one never changes the others.
-{% endhint %}
-
 ## Editing a Pattern After You Insert It
 
-An inserted pattern is just ordinary content — nothing is locked. Click any element to edit it.
-For example, select the heading of a **FAQ Accordion** and change its text in the **Heading
-text** field; the page updates as you type.
+An inserted pattern is just ordinary content, and nothing is locked. Click any element to edit
+it. For example, select the heading of a **FAQ Accordion** and change its text in the **Heading
+text** field, and the page updates as you type.
 
-![Before — the heading reads "Frequently Asked Questions".](<../../../.gitbook/assets/Canvas Patterns - Edit Heading Before.png>)
+![Before: the heading reads "Frequently Asked Questions".](<../../../.gitbook/assets/Canvas Patterns - Edit Heading Before.png>)
 
-![After — the heading now reads "Common Questions About Varbase", updated live.](<../../../.gitbook/assets/Canvas Patterns - Edit Heading After.png>)
+![After: the heading now reads "Common Questions About Varbase", updated live.](<../../../.gitbook/assets/Canvas Patterns - Edit Heading After.png>)
 
 ## For QA
 
-A pattern is working correctly when all of the following hold:
+A pattern is working correctly when all of the following hold.
 
 - The pattern appears on the **Patterns** tab of the Library.
 - **Insert** adds the whole section to the page.
 - Selecting the section, or any piece inside it, opens a settings form.
-- Inserting the same pattern **twice** gives two independent copies; editing one does not change
-  the other.
+- Inserting the same pattern **twice** gives two independent copies, and editing one does not
+  change the other.
 - The page **publishes** and the section renders correctly for a logged-out visitor.
 - No administrative or system components are offered as patterns in the Library.
-- The section passes an accessibility check — for the built demo above, the **Content
-  Accessibility** report (`/admin/reports/editoria11y`) and an axe scan report no WCAG 2 A/AA
-  issues.
+- The section passes an accessibility check. For the built demo, the **Content Accessibility**
+  report (`/admin/reports/editoria11y`) and an axe scan report no WCAG 2 A/AA issues.
 
 {% hint style="warning" %}
 **Good to know.** Patterns are a starting point, not a limit. After you insert one you can add,
-remove or rearrange the pieces inside it freely — the pattern simply saved you the work of
+remove or rearrange the pieces inside it freely. The pattern simply saved you the work of
 building the section from scratch.
 {% endhint %}


### PR DESCRIPTION
Polish for the **Default Canvas Patterns** guide (follow-up to #54).

Closes #56

### What changed
- **Title simplified** to **Default Canvas Patterns** (dropped the "(Ready-Made Sections)" suffix in the page heading and the `SUMMARY.md` entry).
- **No em dashes.** The prose is rewritten into clear, complete sentences that are easier to scan.
- **Steps first.** "How to Use a Pattern" now sits directly after "What Is a Canvas Pattern?", before the 14-pattern catalog, so a reader reaches the how-to without scrolling past the whole catalog.

Content, screenshots and structure are otherwise unchanged.

### Checkpoints
- [x] File an issue about this project
- [x] Addition/Change/Update/Fix to this project
- [ ] Testing to ensure no regression
- [ ] Automated unit/functional testing coverage
- [ ] Developer Documentation support on feature change/addition
- [ ] User Guide Documentation support on feature change/addition
- [ ] UX/UI designer responsibilities
- [ ] Accessibility and Readability
- [ ] Reviewed by a human
- [ ] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Review with the product owner
- [ ] Update Release Notes
- [ ] Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
