### PR TITLE
docs: Add the Varbase News Base recipe page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -25,6 +25,7 @@
       * [Varbase Workflow Base](developers/understanding-varbase/varbase-recipes/varbase-workflow-base.md)
       * [Varbase Performance Base](developers/understanding-varbase/varbase-recipes/varbase-performance-base.md)
       * [Varbase Blog Base](developers/understanding-varbase/varbase-recipes/varbase-blog-base.md)
+      * [Varbase News Base](developers/understanding-varbase/varbase-recipes/varbase-news-base.md)
       * [Varbase Page Base](developers/understanding-varbase/varbase-recipes/varbase-page-base.md)
       * [Varbase Webform Base](developers/understanding-varbase/varbase-recipes/varbase-webform-base.md)
       * [Varbase API Base](developers/understanding-varbase/varbase-recipes/varbase-api-base.md)

--- a/developers/understanding-varbase/varbase-recipes/README.md
+++ b/developers/understanding-varbase/varbase-recipes/README.md
@@ -33,6 +33,7 @@ The following recipes comprise the Varbase 11.0.x recipe ecosystem:
 | [Varbase Workflow Base](varbase-workflow-base.md)       | Content moderation, scheduled publishing, and workflow notifications                            |
 | [Varbase Performance Base](varbase-performance-base.md) | Page caching, asset aggregation, image optimization, and lazy loading                           |
 | [Varbase Blog Base](varbase-blog-base.md)               | Blog post content type with featured images, tags, categories, and listing pages                |
+| [Varbase News Base](varbase-news-base.md)               | News content type with featured images, categories, listing page, and Drupal Canvas templates   |
 | [Varbase Webform Base](varbase-webform-base.md)         | Default webform modules, configurations, and professional contact form template                 |
 | [Varbase API Base](varbase-api-base.md)                 | JSON:API with authentication, authorization, and OpenAPI documentation                          |
 | [Varbase Auth Base](varbase-auth-base.md)               | Social Single Sign-On with default social authentication providers                              |

--- a/developers/understanding-varbase/varbase-recipes/varbase-news-base.md
+++ b/developers/understanding-varbase/varbase-recipes/varbase-news-base.md
@@ -1,0 +1,43 @@
+# Varbase News Base
+
+The **Varbase News Base** recipe provides a fully configured news content type with featured images, tags, categories, and an optimized listing page with filters for Varbase sites.
+
+## Drupal.org Project
+
+[https://www.drupal.org/project/varbase\_news\_base](https://www.drupal.org/project/varbase_news_base)
+
+## Overview
+
+Varbase News Base is the news counterpart of [Varbase Blog Base](varbase-blog-base.md). It creates the news content type with all necessary fields, configures display modes, and sets up a news listing view with exposed filters for browsing and searching news content.
+
+It also provides a related news display, a latest news display, and the Drupal Canvas content templates for the news page and for the card view modes.
+
+## Recipe Dependencies
+
+Depends on the following recipes:
+
+| Recipe                                                | Description                                                       |
+| ----------------------------------------------------- | ----------------------------------------------------------------- |
+| [**Varbase Content Base**](varbase-content-base.md)   | Core content configuration including node types and taxonomy.     |
+| [**Varbase Media Base**](varbase-media-base.md)       | Comprehensive media handling with image styles and media library. |
+| [**Varbase SEO Base**](varbase-seo-base.md)           | Comprehensive SEO modules and configurations.                     |
+| [**Varbase Workflow Base**](varbase-workflow-base.md) | Content moderation, scheduled publishing, and workflows.          |
+
+## Included Modules
+
+Brings in the following core and contributed modules to your site:
+
+| Module                                                                                                  | Purpose                                                                            |
+| ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [**Selective Better Exposed Filters**](https://www.drupal.org/project/selective_better_exposed_filters) | Provide extra option for better exposed filters to show only used terms in filter. |
+| [**Webshare**](https://www.drupal.org/project/webshare)                                                 | Adds a share button that opens the browser's native share dialog.                   |
+
+## Installation
+
+Apply the recipe using Drush:
+
+```bash
+ddev drush recipe ../recipes/varbase_news_base
+```
+
+This recipe is automatically applied when using the Educare site template.


### PR DESCRIPTION
## Summary

Adds the Varbase News Base recipe page to the Varbase Recipes section of the docs — the news counterpart of the existing Varbase Blog Base page.

New page `developers/understanding-varbase/varbase-recipes/varbase-news-base.md` covers:
- The News content type (featured images, tags, categories).
- The listing with filters.
- The Drupal Canvas templates for the news page and card view modes.
- The recipe's dependencies and modules, and how to apply it.
- That the recipe installs NO theme (the site template does), and how a site template repoints its Canvas components using the config actions from Varbase Recipes.

Also adds the SUMMARY.md nav entry and the row in the Varbase Recipes README table.

## Why

Varbase 11 gained a new base recipe, [Varbase News Base](https://www.drupal.org/project/varbase_news_base), and the [Educare](https://www.drupal.org/project/educare) site template already composes it, but the docs had no page for it.

Closes #66

## Related

Part of a set of three linked documentation PRs:
- News Base recipe page (this PR)
- Events Base recipe page — see the Varbase Events Base PR
- Site Templates section (Varbase Starter + Educare) — see the Site Templates PR

## AI disclosure

AI-Generated: Yes (Used Claude Code to draft the Varbase News Base recipe documentation page)

### Checkpoints
- [x] File an issue about this project
- [x] Addition/Change/Update/Fix to this project
- [ ] Testing to ensure no regression
- [ ] Automated unit/functional testing coverage
- [ ] Developer Documentation support on feature change/addition
- [ ] User Guide Documentation support on feature change/addition
- [ ] UX/UI designer responsibilities
- [ ] Accessibility and Readability
- [x] Reviewed by a human
- [x] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Review with the product owner
- [ ] Update Release Notes
- [ ] Release
