### PR TITLE
docs: #79 Document the Varbase AI Figma Base add-on recipe

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -46,6 +46,7 @@
       * [AI Recipe Guardrails Prompt Safety](developers/understanding-varbase/varbase-ai-recipes/ai-recipe-guardrails-prompt-safety.md)
       * [Varbase AI Context](developers/understanding-varbase/varbase-ai-recipes/varbase-ai-context.md)
       * [Varbase AI Safety](developers/understanding-varbase/varbase-ai-recipes/varbase-ai-safety.md)
+      * [Varbase AI Figma Base](developers/understanding-varbase/varbase-ai-recipes/varbase-ai-figma-base.md)
     * [Drupal CMS Recipes](developers/understanding-varbase/drupal-cms-recipes/README.md)
       * [Drupal CMS Admin UI](developers/understanding-varbase/drupal-cms-recipes/drupal-cms-admin-ui.md)
       * [Drupal CMS Anti-Spam](developers/understanding-varbase/drupal-cms-recipes/drupal-cms-anti-spam.md)

--- a/developers/understanding-varbase/basic-concepts.md
+++ b/developers/understanding-varbase/basic-concepts.md
@@ -72,6 +72,7 @@ Optional recipes ship with the project but are not applied by `varbase_starter`.
 
 - **Varbase optional recipes**: `varbase_api_base`, `varbase_auth_base`, `varbase_i18n_base`, `varbase_dev_base`
 - **Varbase AI recipes**: `varbase_ai_base` (which bundles `varbase_ai_editor_assistant`, `varbase_ai_image_alt`, and `varbase_ai_taxonomy_tagging`), plus `varbase_ai_context` and `varbase_ai_safety`
+- **Add-on recipes** (separate Drupal.org projects): `varbase_news_base`, `varbase_events_base`, and `varbase_ai_figma_base`
 
 ## How varbase_starter Orchestrates Everything
 

--- a/developers/understanding-varbase/varbase-ai-recipes/README.md
+++ b/developers/understanding-varbase/varbase-ai-recipes/README.md
@@ -18,9 +18,12 @@ This approach allows site builders to adopt only the AI features they need, keep
 | [AI Recipe Guardrails Prompt Safety](ai-recipe-guardrails-prompt-safety.md) | Installs prompt safety guardrails for the Drupal AI module (XSS, injection, liability topics, jailbreak detection). |
 | [Varbase AI Context](varbase-ai-context.md) | Installs Context Control Center (CCC) with starter brand, editorial, and safety context items for all AI agents. |
 | [Varbase AI Safety](varbase-ai-safety.md) | Bundles prompt safety, PII protection, AI logging with retention, and AI observability for enterprise/GDPR deployments. |
+| [Varbase AI Figma Base](varbase-ai-figma-base.md) | Add-on recipe that sets up the Figma-to-Canvas flow: the AI Figma engine, the Varbase customization for Vartheme BS5, and the Drupal Canvas AI Orchestrator wiring. |
 
 ## Architecture
 
 The **Varbase AI Base** recipe bundles the core AI feature recipes (Editor Assistant, Image Alt, Taxonomy Tagging) and depends on the **Drupal CMS AI** recipe for core provider configuration. Installing Varbase AI Base gives you the AI feature set with OpenAI integration, AI dashboard, and provider configuration that the other recipes build upon.
 
 For enterprise deployments, apply **Varbase AI Safety** on top to enable the full guardrail and observability stack, and apply **Varbase AI Context** to give every AI agent site-specific brand, editorial, and safety knowledge out of the box.
+
+**Varbase AI Figma Base** is a separate add-on project ([drupal.org/project/varbase\_ai\_figma](https://www.drupal.org/project/varbase_ai_figma)) that builds on **Drupal CMS AI** and **Varbase AI Context** to turn Figma designs into Drupal Canvas pages.

--- a/developers/understanding-varbase/varbase-ai-recipes/varbase-ai-figma-base.md
+++ b/developers/understanding-varbase/varbase-ai-recipes/varbase-ai-figma-base.md
@@ -1,0 +1,79 @@
+# Varbase AI Figma Base
+
+The **Varbase AI Figma Base** recipe sets up the Figma-to-Canvas flow on a Varbase site in one step: design in **Figma**, then let the **Drupal Canvas AI** assistant build the page in Drupal — no hand-coding. It installs the general **AI Figma** engine plus the **Varbase AI Figma** customization for the **Vartheme BS5** theme, and wires the Figma tools into the **Drupal Canvas AI Orchestrator**.
+
+## Recipe Type
+
+Varbase AI
+
+## Drupal.org Project
+
+[https://www.drupal.org/project/varbase\_ai\_figma](https://www.drupal.org/project/varbase_ai_figma)
+
+This is a separate add-on project. It does not ship with the Varbase project codebase; require it with Composer first.
+
+## Overview
+
+Varbase AI Figma Base applies the **Drupal CMS AI** recipe first (AI providers and API keys — it never creates its own provider keys), then **Varbase AI Context**, and then installs and configures the Figma stack:
+
+- **AI Figma** reads live Figma design context through the Figma REST API and exposes it to Drupal AI Agent tools.
+- **Varbase AI Figma** tunes that engine for the **Vartheme BS5** theme: layouts, component choices, and a demo Figma file, so a Varbase site builds Canvas pages from a Figma link out of the box.
+- The **Drupal Canvas AI Orchestrator** is taught to resolve a design against what the site already ships before it builds anything: it scans the site inventory (components, saved sections, blocks, and lists) and decides, region by region, whether to **reuse**, **adapt**, or **build**. It reuses an existing component, pattern, block, or view before creating a new one, binds the design to real component inputs, and never freezes live content into static markup.
+- The resolver's tuning — content roles, signal weights, reuse/adapt/build thresholds, and exclusions — lives in the `varbase_ai_figma.settings` configuration, so behavior is adjusted in configuration rather than in code.
+- The recipe also ships curated **AI Agent Modes** for the Figma and Canvas flows (page, section, component, pattern, Figma page, page review, pattern create, and site connect).
+
+## Install-Time Inputs
+
+The recipe asks for two values when applied. Both are optional and can be configured later:
+
+| Input | Purpose |
+|---|---|
+| **Figma access token** | A Figma personal access token with read access. Stored in a dedicated key. Leave empty to fill it in later at **Administration** \ **Configuration** \ **System** \ _**Keys**_. |
+| **Default Figma file key** | The file key from your Figma file URL (`figma.com/design/<FILE_KEY>/...`). Used when a prompt does not include a Figma link. |
+
+## Recipe Dependencies
+
+Depends on the following recipes:
+
+| Recipe | Description |
+|---|---|
+| [**Drupal CMS AI**](../drupal-cms-recipes/drupal-cms-ai.md) | Core AI provider configuration and API keys. |
+| [**Varbase AI Context**](varbase-ai-context.md) | Context Control Center with starter brand, editorial, and safety context items. |
+
+## Included Modules
+
+Brings in the following core and contributed modules to your site:
+
+| Module | Purpose |
+|---|---|
+| [**AI**](https://www.drupal.org/project/ai) | Core AI framework for Drupal. |
+| [**AI Agents**](https://www.drupal.org/project/ai_agents) | AI agents that perform tasks on the site. |
+| [**AI Context**](https://www.drupal.org/project/ai_context) | Context Control Center for AI agents. |
+| [**AI Agent Modes**](https://www.drupal.org/project/ai_agent_modes) | Curated modes that focus an AI agent on one job at a time. |
+| [**AI Figma**](https://www.drupal.org/project/ai_figma) | Reads live Figma design context via the Figma REST API and exposes it to Drupal AI Agent tools. |
+| [**Varbase AI Figma**](https://www.drupal.org/project/varbase_ai_figma) | Varbase customization of AI Figma for the Vartheme BS5 theme, with the design resolver and Canvas build tools. |
+| [**Drupal Canvas AI**](https://www.drupal.org/project/canvas) | The AI assistant inside the Drupal Canvas page editor. |
+| [**Key**](https://www.drupal.org/project/key) | Manages the Figma access token as a key. |
+| [**Easy Encryption**](https://www.drupal.org/project/easy_encryption) | Encrypts stored secrets. |
+| [**Scheduler**](https://www.drupal.org/project/scheduler) | Publishes and unpublishes content on specified dates. |
+
+## Configuration
+
+The recipe applies the following configurations:
+
+- Creates the **Figma access token** key and points **AI Figma** at it, together with the default Figma file key.
+- Imports the **Varbase AI Figma** settings (the design resolver tuning) and the targeted Figma **AI Context** items.
+- Imports the curated **AI Agent Modes** for the Figma and Canvas flows.
+- Wires the design tools into the **Drupal Canvas AI Orchestrator** in working order: understand the design, scan the site inventory, resolve reuse/adapt/build decisions, build the page, connect it to the site (front page, URL aliases, menus, Webforms, and Views), then check and improve the result.
+- Grants the needed permissions so the feature is not administrator-only: **Site Admin** can manage the Figma settings and use the assistant, **Content Admin** and **Content Editor** can use the **Drupal Canvas AI** panel.
+
+## Installation
+
+Require the add-on project, then apply the recipe using Drush:
+
+```bash
+ddev composer require drupal/varbase_ai_figma
+ddev drush recipe ../recipes/varbase_ai_figma_base
+```
+
+After installation, set or verify the Figma access token at **Administration** \ **Configuration** \ **System** \ _**Keys**_, and open any Canvas page to build from a Figma link with the **Drupal Canvas AI** assistant.

--- a/developers/understanding-varbase/varbase-recipes/README.md
+++ b/developers/understanding-varbase/varbase-recipes/README.md
@@ -46,7 +46,7 @@ The following recipes comprise the Varbase 11.0.x recipe ecosystem. The **Applie
 | [Varbase Events Base](varbase-events-base.md)           | Event content type with smart date and location, events listing, and related events             | Add-on |
 
 {% hint style="info" %}
-The [**Varbase AI Recipes**](../varbase-ai-recipes/README.md) are documented in their own section. The **Varbase AI Base** recipe and its feature recipes ship in the project codebase and can be applied on demand.
+The [**Varbase AI Recipes**](../varbase-ai-recipes/README.md) are documented in their own section. The **Varbase AI Base** recipe and its feature recipes ship in the project codebase and can be applied on demand. **Varbase AI Figma Base** is a separate add-on project.
 {% endhint %}
 
 ## Applying a Recipe

--- a/overview/whats-new-in-varbase-11.md
+++ b/overview/whats-new-in-varbase-11.md
@@ -40,6 +40,7 @@ Varbase 11 introduces a suite of **AI integration recipes** that bring artificia
 - **Varbase AI Taxonomy Tagging**: AI-powered taxonomy tagging for content
 - **Varbase AI Context**: Starter brand, editorial, and safety context items for all AI agents
 - **Varbase AI Safety**: Prompt safety and PII guardrails, AI logging, and AI observability
+- **Varbase AI Figma Base** _(add-on)_: Builds Drupal Canvas pages from Figma designs with the Drupal Canvas AI assistant
 
 ## Easy Email Recipes
 


### PR DESCRIPTION
Closes #79

Grounded in the released code: `drupal/varbase_ai_figma` 1.0.0-alpha2 with the `drupal/varbase_ai_figma_base` 1.0.0-alpha2 recipe, required and unpacked into a fresh `drupal/varbase_project:~11.0.0` build.

- New page **Varbase AI Figma Base** under Varbase AI Recipes: overview (AI Figma engine + Varbase customization for Vartheme BS5, reuse/adapt/build design resolver, curated AI Agent Modes), recipe dependencies (Drupal CMS AI, Varbase AI Context), install-time inputs (Figma access token, default file key), included modules, applied configuration, and installation commands.
- Added to the Varbase AI Recipes list and architecture note, the recipes overview hint, the Basic Concepts add-on list, and the What's New in Varbase 11 AI section.
- Wired into `SUMMARY.md`.

AI-Generated: Yes

### Checkpoints
- [x] File an issue about this project
- [x] Addition/Change/Update/Fix to this project
- [ ] Testing to ensure no regression
- [ ] Automated unit/functional testing coverage
- [ ] Developer Documentation support on feature change/addition
- [ ] User Guide Documentation support on feature change/addition
- [ ] UX/UI designer responsibilities
- [ ] Accessibility and Readability
- [ ] Reviewed by a human
- [ ] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Review with the product owner
- [ ] Update Release Notes
- [ ] Release