### PR TITLE
docs: #81 Add the Horizon Aid site template page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -16,6 +16,7 @@
     * [Site Templates](developers/understanding-varbase/site-templates/README.md)
       * [Varbase Starter](developers/understanding-varbase/site-templates/varbase-starter.md)
       * [Educare](developers/understanding-varbase/site-templates/educare.md)
+      * [Horizon Aid](developers/understanding-varbase/site-templates/horizon-aid.md)
     * [Varbase Recipes](developers/understanding-varbase/varbase-recipes/README.md)
       * [Varbase Admin Base](developers/understanding-varbase/varbase-recipes/varbase-admin-base.md)
       * [Varbase Users Base](developers/understanding-varbase/varbase-recipes/varbase-users-base.md)

--- a/developers/understanding-varbase/site-templates/README.md
+++ b/developers/understanding-varbase/site-templates/README.md
@@ -10,6 +10,7 @@ A site template is applied **during** the site installation. It is not applied w
 | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | [Varbase Starter](varbase-starter.md) | Main site template recipe that orchestrates the full Varbase installation                            |
 | [Educare](educare.md)                                    | Education site template for schools, universities, academies, and e-learning, on Vartheme BS5 Educare |
+| [Horizon Aid](horizon-aid.md)                            | NGO and humanitarian site template for nonprofits, charities, foundations, and aid organizations, on Vartheme BS5 Horizon Aid |
 
 ## What a Site Template Owns
 

--- a/developers/understanding-varbase/site-templates/horizon-aid.md
+++ b/developers/understanding-varbase/site-templates/horizon-aid.md
@@ -1,0 +1,54 @@
+# Horizon Aid
+
+The **Horizon Aid** site template is a site template for NGOs, nonprofits, charities, foundations, and humanitarian aid organizations. It is built on Varbase with the [Vartheme BS5 Horizon Aid](https://www.drupal.org/project/vartheme_bs5_horizonaid) front-end theme.
+
+## Drupal.org Project
+
+[https://www.drupal.org/project/horizonaid](https://www.drupal.org/project/horizonaid)
+
+## Recipe Type
+
+Site recipe (full site template)
+
+## Overview
+
+Horizon Aid composes the Varbase base recipes, installs its own theme, and adds what is its own: the pages, the Drupal Canvas patterns, and the demo content.
+
+It ships home, about, resources, programmes, events, countries, and donation pages, all built with Drupal Canvas. Country presence pages describe the organization's role, its work on the ground, key figures, and partners, with demo countries included. Blog posts cover field updates and reports.
+
+## What It Composes
+
+| Section                                                                | Comes from                                                              |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Events: the Event content type, the events listing, and related events | [Varbase Events Base](../varbase-recipes/varbase-events-base.md)        |
+| Blog: the Blog post content type and its listing                       | [Varbase Blog Base](../varbase-recipes/varbase-blog-base.md)            |
+| Pages, media, editor, workflow, SEO, forms, search, and the admin UI   | The Varbase and Drupal CMS base recipes                                 |
+
+## Included Themes
+
+| Theme                                                                                   | Description                                                  |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| [**Vartheme BS5 Horizon Aid**](https://www.drupal.org/project/vartheme_bs5_horizonaid)   | NGO and humanitarian theme for Varbase, based on Vartheme BS5. |
+
+## Installation
+
+Create a Varbase project, require the Horizon Aid recipe, then choose **Horizon Aid** in the installer:
+
+```bash
+composer create-project drupal/varbase_project:~11.0.0 PROJECT_DIR_NAME --no-dev --no-interaction
+composer require drupal/horizonaid:1.0.x-dev
+```
+
+With DDEV:
+
+```bash
+mkdir my_horizonaid_site
+cd my_horizonaid_site
+ddev config --project-type=drupal11 --docroot=web --php-version=8.4
+ddev start
+ddev composer create-project "drupal/varbase_project:~11.0.0"
+ddev composer require drupal/horizonaid:1.0.x-dev
+ddev launch
+```
+
+Finish the installation in the browser and select **Horizon Aid** in the **Choose a site template** step.


### PR DESCRIPTION
Closes #81

Grounded in the released code (`drupal/horizonaid` 1.0.x-dev `recipe.yml`) and the Drupal.org project page.

- New page **Horizon Aid** under Site Templates, matching the Educare page style: overview (home, about, resources, programmes, events, countries, and donation pages built with Drupal Canvas; country presence pages with demo countries), what it composes (**Varbase Events Base**, **Varbase Blog Base**, the Varbase and Drupal CMS base recipes), the **Vartheme BS5 Horizon Aid** theme, and installation commands.
- Listed in the Site Templates section README and `SUMMARY.md`.

Note: touches the same `SUMMARY.md` area as the other open docs PRs — trivial to resolve if they land in any order.

AI-Generated: Yes

### Checkpoints
- [x] File an issue about this project
- [x] Addition/Change/Update/Fix to this project
- [ ] Testing to ensure no regression
- [ ] Automated unit/functional testing coverage
- [ ] Developer Documentation support on feature change/addition
- [ ] User Guide Documentation support on feature change/addition
- [ ] UX/UI designer responsibilities
- [ ] Accessibility and Readability
- [x] Reviewed by a human
- [x] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Review with the product owner
- [ ] Update Release Notes
- [ ] Release