### PR TITLE
docs: #83 List Varbase Components and Smart Date on the Varbase Events Base page

### DIFF
--- a/developers/understanding-varbase/varbase-recipes/varbase-events-base.md
+++ b/developers/understanding-varbase/varbase-recipes/varbase-events-base.md
@@ -30,6 +30,8 @@ Brings in the following core and contributed modules to your site:
 
 | Module                                                                                                  | Purpose                                                                            |
 | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [**Varbase Components**](https://www.drupal.org/project/varbase_components)                             | The Varbase library of single-directory components used by the content templates.  |
+| [**Smart Date**](https://www.drupal.org/project/smart_date)                                             | The date field the event's When field is built on.                                 |
 | [**Selective Better Exposed Filters**](https://www.drupal.org/project/selective_better_exposed_filters) | Provide extra option for better exposed filters to show only used terms in filter. |
 | [**Webshare**](https://www.drupal.org/project/webshare)                                                 | Adds a share button that opens the browser's native share dialog.                   |
 


### PR DESCRIPTION
Closes #83

Verified against the released recipe (`drupal/varbase_events_base`, required and unpacked on a fresh `drupal/varbase_project:~11.0.0` build): the `recipe.yml` install list is `varbase_components`, `selective_better_exposed_filters`, `webshare`, `smart_date`. The page's Included Modules table was missing **Varbase Components** and **Smart Date**; both rows added.

The **Varbase News Base** page was verified against its released recipe at the same time and matches — no changes needed there.

AI-Generated: Yes

### Checkpoints
- [x] File an issue about this project
- [x] Addition/Change/Update/Fix to this project
- [ ] Testing to ensure no regression
- [ ] Automated unit/functional testing coverage
- [ ] Developer Documentation support on feature change/addition
- [ ] User Guide Documentation support on feature change/addition
- [ ] UX/UI designer responsibilities
- [ ] Accessibility and Readability
- [x] Reviewed by a human
- [x] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Review with the product owner
- [ ] Update Release Notes
- [ ] Release